### PR TITLE
Fixes the broken link reference to job status 

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -722,7 +722,7 @@ paths:
       tags:
         - runs
       summary: Delete run
-      description: Deletes a specified run and optionally its associated database data, input files, output files, and logs. This is an asynchronous operation that must be [checked for completion.](/api-sdk/api-reference/jobs/status)
+      description: Deletes a specified run and optionally its associated database data, input files, output files, and logs. This is an asynchronous operation that must be [checked for completion.](/api-sdk/api-reference/jobs/job-status)
       parameters:
         - $ref: '#/components/parameters/run_id'
         - $ref: '#/components/parameters/ib_context'


### PR DESCRIPTION
The reference link for retrieving job status was incorrect and redirected to a dead link. This PR includes changes to correct it.