### PR TITLE
[DR-4929] Updated data type for Page Number in Source Pages

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2803,7 +2803,10 @@ components:
       type: object
       properties:
         page_number:
-          type: integer
+          oneOf:
+            - type: integer
+            - type: number
+              format: float
           description: The number of the page referenced in the source document.
         bboxes:
           type: array


### PR DESCRIPTION
`Issue`:- Get Query Status is failing when query is raised using multistep model.
`RCA`:- Multistep model is returning float value (1.0) in page number but int is expected. Hence the pyndatic validation is failing.
`Fix`: Update the data type for Source Page Number where it should be able to accommodate int or float value.

Slack Thread:- https://instabase.slack.com/archives/C05BJCNKZAM/p1739957086695799


Test:- Generated SDK and Docs successfully with updated yml file
<img width="1713" alt="Screenshot 2025-02-19 at 6 50 36 PM" src="https://github.com/user-attachments/assets/bb191f77-871b-4b93-ade2-b183ed8f03fa" />



