### PR TITLE
Fix timestamp units in list and input_dir type

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -661,12 +661,12 @@ paths:
           name: from_timestamp
           schema:
             type: integer
-          description: Filter runs starting from this timestamp. Timestamp in s. Defaults to 24 hours before the current time.
+          description: Filter runs starting from this timestamp. Timestamp in Unix time in seconds. Defaults to 24 hours before the current time.
         - in: query
           name: to_timestamp
           schema:
             type: integer
-          description: Filter runs up to this timestamp. Timestamp in s. Defaults to the current time.
+          description: Filter runs up to this timestamp. Timestamp in Unix time in seconds. Defaults to the current time.
         - in: query
           name: limit
           schema:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -661,12 +661,12 @@ paths:
           name: from_timestamp
           schema:
             type: integer
-          description: Filter runs starting from this timestamp. Defaults to one week before the current time.
+          description: Filter runs starting from this timestamp. Timestamp in s. Defaults to 24 hours before the current time.
         - in: query
           name: to_timestamp
           schema:
             type: integer
-          description: Filter runs up to this timestamp. Defaults to the current time.
+          description: Filter runs up to this timestamp. Timestamp in s. Defaults to the current time.
         - in: query
           name: limit
           schema:
@@ -765,7 +765,7 @@ paths:
                   type: integer
                   description: Required unless using `input_dir` or `manual_upstream_integration`. The batch ID of a batch created with the [Batches endpoint](/api-sdk/api-reference/batches/create-batch/). All files uploaded to the batch are used as input for the run.
                 input_dir:
-                  type: integer
+                  type: string
                   description: Required unless using `batch_id` or `manual_upstream_integration`. The path of the input folder in a connected drive or Instabase Drive. See [Specifying file paths](/api-sdk/api-reference/run-reference/).
                 manual_upstream_integration:
                   type: boolean


### PR DESCRIPTION
- In the ListRuns API, specify the timestamp units as seconds. 
- In the ListRuns API, change from_timestamp description to say it default to 24 hours before current time
- Fix data type of input_dir