### PR TITLE
Adding information about custom values we return for a run

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3030,6 +3030,12 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/fileWithDocuments'
+        keys:
+          type: object
+          properties:
+            custom:
+              type: object
+              description: key-value pair of custom variables which were set for a run. 
         has_more:
           type: boolean
           description: Indicates whether additional results are available beyond those included in the current response. Use the `file_offset` query parameter to specify the starting point when fetching the next set of results.


### PR DESCRIPTION
Since 25.24 we started additionally returning key-value dictionary of all custom values which were set for a run as a separate field: "keys": {
    "custom": {},
  }