### PR TITLE
[EPD-4383] Updated SDK changes for new settings in conversation API

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1351,6 +1351,12 @@ paths:
                   type: boolean
                   description: Defines whether to generate and save thumbnails of each image file generated when processing the document. One `.jpeg` thumbnail--a small image representation of the larger image--per document page is saved. If storage space is a consideration, consider disabling for documents with many pages.
                   default: true
+                enable_multilanguage_support:
+                  type: boolean
+                  description: Defines whether to enable the multi-language support. If the conversation contains non-english documents then consider enabling this. It will enable the multi-language support in standard mode by default. It will [supports most languages](/overview/languages#standard-non-latin-language-set) that use non-Latin characters. It will be only available for commercial users.
+                enable_multilanguage_advanced_mode:
+                  type: boolean
+                  description: Defines whether to enable the advanced mode for the multi-language support. It will enable the multi-language support in advanced mode. It will [supports additional languages](/overview/languages#advanced-non-latin-language-set) that use non-Latin characters, including Greek, Hebrew, Thai, and more. It will be only available for enterprise users.
               required:
                 - files
       responses:


### PR DESCRIPTION
## Description
We have introduced new settings to enable non-Latin support in the create conversation API by exposing the following arguments.

1. `enable_multilanguage_support`: false,
2. `enable_multilanguage_advanced_mode`: false,

It will help in extending support for non-Latin documents. This PR deals with exposing these newly added arguments to the SDK
## Test Plan
Tested in the playground and it's working as expected
<img width="1694" alt="Screenshot 2025-06-19 at 5 32 43 PM" src="https://github.com/user-attachments/assets/30432865-f759-457a-8935-9e66897dd6be" />


## Checklist before submitting
  - [x] Include the Jira issue key (like INSIGHTS-1234) in the PR title.
  - [x] Add at least one label (a PR may contain multiple labels).
  - [x] Please review our [PR and code best-practices](https://docs.google.com/document/d/1v4uw2Ziudu03dsARAULB2XeJcsL9bEA3ueGT1BzDgik/edit#).

<!---
Please Add Labels based on Change classification
(you can add more than one)

| Change Type     | Label           |
| --------------- | --------------- |
| New Feature     | feature         |
| Bug fix         | bugfix          |
| Maintenance     | chore           |
| Breaking Change | breaking-change |
| Documentation   | doc             |
| Proto Change    | proto           |
| Security        | security        |
| Config Change   | config          |
| Proto Change    | proto           |
| Auto Tests      | tests           |
-->
