### PR TITLE
Fix post-processed-pdf data type

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3118,10 +3118,8 @@ components:
           items:
             type: string
         post_processed_pdf_path:
-          type: array
-          description: An array of strings, each representing a path to post-processed PDFs.
-          items:
-            type: string
+          type: string
+          description: Path to post-processed PDF.
         class_edit_history:
           type: array
           description: An array containing the history of edits to the document class.


### PR DESCRIPTION
Currently it is labelled as array of strings. It should be just string. 