### PR TITLE
Add Python code samples without SDK

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3676,7 +3676,7 @@ components:
         type: string
       required: false
       description: Specify whether to use your community account or organization account to complete the request. To use your community account, define as your user ID. To use your organization account, define as your organization ID.
-        If unspecified, defaults to community account context. See [Authorization and context identification](/api-sdk/authorization#ib-context-header) for details.
+                   If unspecified, defaults to community account context. See [Authorization and context identification](/api-sdk/authorization#ib-context-header) for details.
     batch_id:
       in: path
       name: batch_id

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -72,6 +72,7 @@ paths:
                     -H "Content-Type: application/json" \
                     -d '{"name": "test"}'
             - sdk: python
+              name: with SDK
               code: |
                   # AI Hub Python SDK example
                   from aihub import AIHub
@@ -134,6 +135,7 @@ paths:
                     --data-urlencode "workspace=my-workspace" \
                     --data-urlencode "limit=100"
             - sdk: python
+              name: with SDK
               code: |
                   # AI Hub Python SDK example
                   from aihub import AIHub
@@ -143,6 +145,30 @@ paths:
                                  ib_context="<IB-CONTEXT>")
                   batches = client.batches.list(workspace="my-workspace",
                                                 limit=100)
+            - sdk: python
+              name: without SDK
+              code: |
+                import requests
+                
+                url = "https://aihub.instabase.com/api/v2/batches"
+                headers = { "Authorization": "Bearer abcdefghijklmnopqrst1234567890",
+                            "IB-Context": 'john.doe_acme.com' }
+                
+                # create query parameters
+                params = { "workspace": "Development-Workspace",
+                           "limit": 100 }
+                
+                # Make the GET request
+                response = requests.get(url,
+                                        headers=headers,
+                                        params=params)
+                
+                # handle the response
+                if response.status_code == 200:
+                    batches = response.json()
+                    print(f"Retrieved {len(batches['batches'])} batches")
+                else:
+                    print(f"Error: { response.status_code } - { response.text }")
 
   /v2/batches/{batch_id}:
     get:
@@ -173,6 +199,7 @@ paths:
                     -H "Authorization: Bearer ${API_TOKEN}"\
                     -H "IB-Context: ${IB_CONTEXT}"
             - sdk: python
+              name: with SDK
               code: |
                   # AI Hub Python SDK example
                   from aihub import AIHub
@@ -209,6 +236,7 @@ paths:
                     -H "Authorization: Bearer ${API_TOKEN}"\
                     -H "IB-Context: ${IB_CONTEXT}"
             - sdk: python
+              name: with SDK
               code: |
                   # AI Hub Python SDK example
                   from aihub import AIHub
@@ -225,6 +253,25 @@ paths:
                       if job_status.state == 'COMPLETE':
                           break
                       time.sleep(5)
+            - sdk: python
+              name: without SDK
+              code: |
+                import requests
+                
+                url = "https://aihub.instabase.com/api/v2/batches/123456"
+                headers = { "Authorization": "Bearer abcdefghijklmnopqrst1234567890",
+                                             "IB-Context": 'john.doe_acme.com' }
+                
+                # Make the DELETE request
+                response = requests.delete(url,
+                                           headers=headers)
+                
+                # handle the response
+                if response.status_code == 202:
+                    job_response = response.json()
+                    print(f"Batch deletion job started with ID: {job_response['job_id']}")
+                else:
+                    print(f"Error: {response.status_code} - {response.text}")
 
   /v2/batches/{batch_id}/files:
     get:
@@ -289,6 +336,7 @@ paths:
                   -H "Authorization: Bearer ${API_TOKEN}"\
                   -H "IB-Context: ${IB_CONTEXT}"
             - sdk: python
+              name: with SDK
               code: |
                 # AI Hub Python SDK example
                 from aihub import AIHub
@@ -297,6 +345,25 @@ paths:
                                api_key="<API-TOKEN>",
                                ib_context="<IB-CONTEXT>")
                 resp = client.batches.list_files(batch_id="<BATCH-ID>")
+            - sdk: python
+              name: without SDK
+              code: |
+                import requests
+                
+                url = "https://aihub.instabase.com/api/v2/batches/123456/files"
+                headers = { "Authorization": "Bearer abcdefghijklmnopqrst1234567890",
+                            "IB-Context": "john.doe_acme.com" }
+                
+                # Make the GET request
+                response = requests.get(url,
+                                        headers=headers)
+                
+                # handle the response
+                if response.status_code == 200:
+                    files = response.json()
+                    print(f"Retrieved {len(files['nodes'])} files")
+                else:
+                    print(f"Error: {response.status_code} - {response.text}")
 
   /v2/batches/{batch_id}/files/{filename}:
     put:
@@ -348,6 +415,7 @@ paths:
                     -H "Content-Type: application/octet-stream" \
                     --upload-file '<LOCAL_FILEPATH>' # Full path to the file in the machine that's making the request
             - sdk: python
+              name: with SDK
               code: |
                   # AI Hub Python SDK example
                   from aihub import AIHub
@@ -358,6 +426,30 @@ paths:
                   client.batches.add_file(batch_id="<BATCH-ID>",
                                           file_name="test.pdf",
                                           file=open("test.pdf", "rb"))
+            - sdk: python
+              name: without SDK
+              code: |
+                import requests
+                
+                url = "https://aihub.instabase.com/api/v2/batches/12345/files/test.pdf"
+                headers = { "Authorization": "Bearer abcdefghijklmnopqrst1234567890",
+                                             "IB-Context": 'john.doe_acme.com',
+                                             "Content-Type": "application/octet-stream" }
+                
+                # Read the file contents
+                with open('path/to/local/test.pdf', 'rb') as file:
+                    file_content = file.read()
+                
+                # Make the PUT request
+                response = requests.put(url,
+                                        headers=headers,
+                                        data=file_content)
+                
+                # handle the response
+                if response.status_code == 204:
+                    print("File uploaded successfully")
+                else:
+                    print(f"Error: {response.status_code} - {response.text}")
 
     delete:
       operationId: deleteFileFromBatch
@@ -389,6 +481,7 @@ paths:
                     -H "Authorization: Bearer ${API_TOKEN}"\
                     -H "IB-Context: ${IB_CONTEXT}"
             - sdk: python
+              name: with SDK
               code: |
                   # AI Hub Python SDK example
                   from aihub import AIHub
@@ -398,6 +491,24 @@ paths:
                                  ib_context="<IB-CONTEXT>")
                   resp = client.batches.delete_file("<BATCH-ID>",
                                                     "<FILENAME>")
+            - sdk: python
+              name: without SDK
+              code: |
+                import requests
+                
+                url = "https://aihub.instabase.com/api/v2/batches/12345/files/test.pdf"
+                headers = { "Authorization": "Bearer abcdefghijklmnopqrst1234567890",
+                            "IB-Context": 'john.doe_acme.com' }
+                
+                # Make the DELETE request
+                response = requests.delete(url,
+                                           headers=headers)
+                
+                # handle the response
+                if response.status_code == 202:
+                    print("File deletion request accepted")
+                else:
+                    print(f"Error: {response.status_code} - {response.text}")
 
   /v2/batches/jobs/{job_id}:
     get:
@@ -431,6 +542,7 @@ paths:
                     -H "Authorization: Bearer ${API_TOKEN}"\
                     -H "IB-Context: ${IB_CONTEXT}"
             - sdk: python
+              name: with SDK
               code: |
                   # AI Hub Python SDK example
                   from aihub import AIHub
@@ -439,6 +551,25 @@ paths:
                                  api_key="<API-TOKEN>",
                                  ib_context="<IB-CONTEXT>")
                   resp = client.batches.poll_job("<JOB-ID>")
+            - sdk: python
+              name: without SDK
+              code: |
+                import requests
+                
+                url = "https://aihub.instabase.com/api/v2/batches/jobs/a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+                headers = { "Authorization": "Bearer abcdefghijklmnopqrst1234567890",
+                            "IB-Context": 'john.doe_acme.com' }
+                
+                # Make the GET request
+                response = requests.get(url,
+                                        headers=headers)
+                
+                # handle the response
+                if response.status_code == 200:
+                    job_status = response.json()
+                    print(f"Job status: {job_status['state']}")
+                else:
+                    print(f"Error: {response.status_code} - {response.text}")
 
   /v2/apps/runs:
     post:
@@ -567,7 +698,7 @@ paths:
                           "app_name": "<APP-NAME>"
                         }'
             - sdk: python
-              name: Simple request
+              name: Simple request with SDK
               code: |
                   # AI Hub Python SDK example
                   from aihub import AIHub
@@ -578,9 +709,33 @@ paths:
 
                   result = client.apps.runs.create(app_name='<APP-NAME>',
                                                    batch_id=<BATCH-ID>)
-        - code-samples:
+            - sdk: python
+              name: Simple request without SDK
+              code: |
+                import requests
+                
+                url = "https://aihub.instabase.com/api/v2/apps/runs"
+                headers = { "Authorization": "Bearer abcdefghijklmnopqrst1234567890",
+                            "IB-Context": 'john.doe_acme.com',
+                            "Content-Type": "application/json" }
+                
+                # create the request payload
+                data = { "batch_id": "123456",
+                         "app_name": "My App" }
+                
+                # Make the POST request
+                response = requests.post(url,
+                                         headers=headers,
+                                         json=data)
+                
+                # handle the response
+                if response.status_code == 200:
+                    run = response.json()
+                    print(f"Run started with ID: {run['id']}")
+                else:
+                    print(f"Error: {response.status_code} - {response.text}")
             - sdk: curl
-              name: Post-processed-pdf generation enabled
+              name: Post-processed-pdf generation
               code: |
                   curl "${API_ROOT}/v2/apps/runs" \
                     -H "Authorization: Bearer ${API_TOKEN}" \
@@ -596,7 +751,7 @@ paths:
                           }
                         }'
             - sdk: python
-              name: Post-processed-pdf generation enabled
+              name: Post-processed-pdf generation with SDK
               code: |
                   # AI Hub Python SDK example
                   from aihub import AIHub
@@ -719,6 +874,7 @@ paths:
                     -H "Authorization: Bearer ${API_TOKEN}"`
                     -H "IB-Context: ${IB_CONTEXT}"
             - sdk: python
+              name: with SDK
               code: |
                   # AI Hub Python SDK example
                   from aihub import AIHub
@@ -727,6 +883,25 @@ paths:
                                  api_key="<API-TOKEN>",
                                  ib_context="<IB-CONTEXT>")
                   runs = client.apps.runs.list()
+            - sdk: python
+              name: without SDK
+              code: |
+                import requests
+                
+                url = "https://aihub.instabase.com/api/v2/apps/runs"
+                headers = { "Authorization": "Bearer abcdefghijklmnopqrst1234567890",
+                            "IB-Context": 'john.doe_acme.com' }
+                
+                # Make the GET request
+                response = requests.get(url,
+                                        headers=headers)
+                
+                # handle the response
+                if response.status_code == 200:
+                    runs = response.json()
+                    print(f"Retrieved {len(runs['runs'])} runs")
+                else:
+                    print(f"Error: {response.status_code} - {response.text}")
 
   /v2/apps/deployments/{deployment-id}/runs:
     post:
@@ -843,6 +1018,7 @@ paths:
                         "batch_id": <BATCH-ID>,
                       }'
             - sdk: python
+              name: with SDK
               code: |
                   # AI Hub Python SDK example
                   from aihub import AIHub
@@ -852,6 +1028,30 @@ paths:
                                  ib_context="<IB-CONTEXT>")
 
                   result = client.apps.deployments.runs.create(deployment_id='<DEPLOYMENT-ID>', batch_id=<BATCH-ID>)
+            - sdk: python
+              name: without SDK
+              code: |
+                import requests
+                
+                url = "https://aihub.instabase.com/api/v2/apps/deployments/12345678-abcde-1234-abcd-123456789012/runs"
+                headers = { "Authorization": "Bearer abcdefghijklmnopqrst1234567890",
+                            "IB-Context": 'john.doe_acme.com',
+                            "Content-Type": "application/json" }
+                
+                # create the request payload
+                data = { "batch_id": "123456" }
+                
+                # Make the POST request
+                response = requests.post(url,
+                                        headers=headers,
+                                        json=data)
+                
+                # handle the response
+                if response.status_code == 202:
+                    run = response.json()
+                    print(f"Deployment run started with ID: {run['id']}")
+                else:
+                    print(f"Error: {response.status_code} - {response.text}")
 
   /v2/apps/runs/{run_id}:
     get:
@@ -886,6 +1086,7 @@ paths:
                     -H "Authorization: Bearer ${API_TOKEN}"\
                     -H "IB-Context: ${IB_CONTEXT}"
             - sdk: python
+              name: with SDK
               code: |
                   # AI Hub Python SDK example
                   from aihub import AIHub
@@ -895,6 +1096,26 @@ paths:
                                  ib_context="<IB-CONTEXT>")
 
                   status = client.apps.runs.status('<RUN-ID>')
+            - sdk: python
+              name: without SDK
+              code: |
+                import requests
+                
+                url = "https://aihub.instabase.com/api/v2/apps/runs/a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+                headers = { "Authorization": "Bearer abcdefghijklmnopqrst1234567890",
+                            "IB-Context": 'john.doe_acme.com' }
+                
+                # Make the GET request
+                response = requests.get(url,
+                                        headers=headers)
+                
+                # handle the response
+                if response.status_code == 200:
+                    run = response.json()
+                    print(f"Run status: {run['status']}")
+                else:
+                    print(f"Error: {response.status_code} - {response.text}")
+
     delete:
       operationId: deleteRun
       x-fern-audiences:
@@ -967,6 +1188,7 @@ paths:
                   -H "Authorization: Bearer ${API_TOKEN}"\
                   -H "IB-Context: ${IB-CONTEXT}"
             - sdk: python
+              name: with SDK
               code: |
                   # AI Hub Python SDK example
                   from aihub import AIHub
@@ -991,6 +1213,25 @@ paths:
                           if job_status.state == 'COMPLETE':
                               job_ids.remove(job_id)
                       time.sleep(5)
+            - sdk: python
+              name: without SDK
+              code: |
+                import requests
+                
+                url = "https://aihub.instabase.com/api/v2/apps/runs/a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+                headers = { "Authorization": "Bearer abcdefghijklmnopqrst1234567890",
+                            "IB-Context": 'john.doe_acme.com' }
+                
+                # Make the DELETE request
+                response = requests.delete(url,
+                                          headers=headers)
+                
+                # handle the response
+                if response.status_code == 202:
+                    job_response = response.json()
+                    print("Run deletion request accepted")
+                else:
+                    print(f"Error: {response.status_code} - {response.text}")
 
   /v2/apps/runs/{run_id}/results:
     get:
@@ -1177,8 +1418,14 @@ paths:
               keys:
                 - custom: {}
           code-samples:
-            - sdk: python
+            - sdk: curl
               name: Simple request
+              code: |
+                curl "${API_ROOT}/v2/apps/runs/<RUN-ID>/results" \
+                -H "Authorization: Bearer ${API_TOKEN}"`
+                -H "IB-Context: ${IB_CONTEXT}"
+            - sdk: python
+              name: Simple request with SDK
               code: |
                   # AI Hub Python SDK example
 
@@ -1187,12 +1434,25 @@ paths:
                                  api_key="<API-TOKEN>",
                                  ib_context="<IB-CONTEXT>")
                   results = client.apps.runs.results('<RUN-ID>')
-            - sdk: curl
-              name: Simple request
+            - sdk: python
+              name: Simple request without SDK
               code: |
-                  curl "${API_ROOT}/v2/apps/runs/<RUN-ID>/results" \
-                  -H "Authorization: Bearer ${API_TOKEN}"`
-                  -H "IB-Context: ${IB_CONTEXT}"
+                import requests
+                
+                url = "https://aihub.instabase.com/api/v2/apps/runs/a1b2c3d4-e5f6-7890-abcd-ef1234567890/results"
+                headers = { "Authorization": "Bearer abcdefghijklmnopqrst1234567890",
+                            "IB-Context": 'john.doe_acme.com' }
+                
+                # Make the GET request
+                response = requests.get(url,
+                                        headers=headers)
+                
+                # handle the response
+                if response.status_code == 200:
+                    results = response.json()
+                    print(f"Retrieved results for {len(results['files'])} files")
+                else:
+                    print(f"Error: {response.status_code} - {response.text}")
         - path-parameters:
             run_id: 1234-1235
           response:
@@ -1237,11 +1497,16 @@ paths:
                       post_processed_paths:
                         - "instabase-org/orguser/fs/S3 Drive/app-runs/dd97-42cb-8b8e-28a63066887e/4180-8508-b103afb67185/s1_process_files/images/test2.png.PNG"
           code-samples:
-            - sdk: python
+            - sdk: curl
               name: Using query parameters
               code: |
-                  # AI Hub Python SDK example
-                  from aihub import AIHub
+                curl "${API_ROOT}/v2/apps/runs/<RUN-ID>/results?include_confidence_scores=true&include_source_info=true" \
+                  -H "Authorization: Bearer ${API_TOKEN}"`
+            - sdk: python
+              name: Using query parameters with SDK
+              code: |
+                # AI Hub Python SDK example
+                from aihub import AIHub
 
                   client = AIHub(api_root="<API-ROOT>",
                                  api_key="<API-TOKEN>",
@@ -1249,13 +1514,29 @@ paths:
                   results = client.apps.runs.results('<RUN-ID>',
                                                      include_confidence_score=True,
                                                      include_source_info=True)
-            - sdk: curl
-              name: Using query parameters
-              code: |
-                  curl "${API_ROOT}/v2/apps/runs/<RUN-ID>/results?include_confidence_scores=true&include_source_info=true" \
-                    -H "Authorization: Bearer ${API_TOKEN}"`
             - sdk: python
-              name: Retrieving paginated results
+              name: Using query parameters without SDK
+              code: |
+                import requests
+                
+                url = ("https://aihub.instabase.com/api/v2/apps/runs/a1b2c3d4-e5f6-7890-abcd-ef1234567890/results"
+                       "?include_confidence_scores=true"
+                       "&include_source_info=true")
+                headers = { "Authorization": "Bearer abcdefghijklmnopqrst1234567890",
+                            "IB-Context": 'john.doe_acme.com' }
+                
+                # Make the GET request
+                response = requests.get(url,
+                                        headers=headers)
+                
+                # handle the response
+                if response.status_code == 200:
+                    results = response.json()
+                    print(f"Retrieved results for {len(results['files'])} files")
+                else:
+                    print(f"Error: {response.status_code} - {response.text}")
+            - sdk: python
+              name: Retrieving paginated results with SDK
               code: |
                   # AI Hub Python SDK example
                   # The results from this endpoint are paginated.
@@ -1400,6 +1681,7 @@ paths:
                     -F files="@/path/to/test.pdf" \
                     -F files="@/path/to/test2.pdf"
             - sdk: python
+              name: with SDK
               code: |
                   # AI Hub Python SDK example
                   from aihub import AIHub
@@ -1420,6 +1702,43 @@ paths:
                     enable_multilanguage_support = False, # Optional
                     enable_multilanguage_advanced_mode = False, # Optional
                     files=['test.pdf', 'test2.pdf'])
+            - sdk: python
+              name: without SDK
+              code: |
+                import requests
+                
+                url = "https://aihub.instabase.com/api/v2/conversations"
+                headers = { "Authorization": "Bearer abcdefghijklmnopqrst1234567890",
+                            "IB-Context": 'john.doe_acme.com' }
+                
+                files = [
+                    ('files', ('test1.pdf', open('test1.pdf', 'rb'), 'application/pdf')),
+                    ('files', ('test2.pdf', open('test2.pdf', 'rb'), 'application/pdf'))
+                ]
+                
+                data = { 'name': 'MyConversation',
+                        'description': 'sample conversation',
+                        'org': 'my-organization-id',
+                        'workspace': 'Development-Workspace',
+                        'enable_object_detection': 'false',
+                        'enable_entity_detection': 'true',
+                        'write_converted_image': 'true',
+                        'write_thumbnail': 'true',
+                        'enable_multilanguage_support': 'false',
+                        'enable_multilanguage_advanced_mode': 'false' }
+                
+                # make the POST request
+                response = requests.post(url,
+                                        headers=headers,
+                                        files=files,
+                                        data=data)
+                
+                # handle the response
+                if response.status_code == 201:
+                    conversation = response.json()
+                    print(f"Conversation created with ID: {conversation['id']}")
+                else:
+                    print(f"Error: {response.status_code} - {response.text}")
 
     get:
       operationId: listConversations
@@ -1460,6 +1779,7 @@ paths:
                     -H "Authorization: Bearer ${API_TOKEN}"\
                     -H "IB-Context: ${IB_CONTEXT}"
             - sdk: python
+              name: with SDK
               code: |
                   # AI Hub Python SDK example
                   from aihub import AIHub
@@ -1468,6 +1788,26 @@ paths:
                                  api_key="<API-TOKEN>",
                                  ib_context="<IB-CONTEXT>")
                   conversations = client.conversations.list()
+            - sdk: python
+              name: without SDK
+              code: |
+                import requests
+                
+                url = "https://aihub.instabase.com/api/v2/conversations"
+                headers = { "Authorization": "Bearer abcdefghijklmnopqrst1234567890",
+                            "IB-Context": 'john.doe_acme.com' }
+                
+                # make the GET request
+                response = requests.get(url,
+                                        headers=headers)
+                
+                # handle the response
+                if response.status_code == 200:
+                    conversations = response.json()
+                    print(f"Retrieved {len(conversations['conversations'])} conversations")
+                else:
+                    print(f"Error: {response.status_code} - {response.text}")
+
   /v2/conversations/{conversation_id}:
     get:
       operationId: getConversation
@@ -1501,6 +1841,7 @@ paths:
                     -H "Authorization: Bearer ${API_TOKEN}"\
                     -H "IB-Context: ${IB_CONTEXT}"
             - sdk: python
+              name: with SDK
               code: |
                   # AI Hub Python SDK example
                   from aihub import AIHub
@@ -1549,6 +1890,7 @@ paths:
                     -H "IB-Context: ${IB_CONTEXT}"\
                     -H "Content-Type: application/json"
             - sdk: python
+              name: with SDK
               code: |
                   # AI Hub Python SDK example
                   from aihub import AIHub
@@ -1559,6 +1901,30 @@ paths:
                   status = client.conversations.update('<CONVERSATION-ID>',
                                                       name='<CONVERSATION-NAME>',
                                                       description='<CONVERSATION-DESCRIPTION>')
+            - sdk: python
+              name: without SDK
+              code: |
+                import requests
+                
+                url = "https://aihub.instabase.com/api/v2/conversations/a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+                headers = { "Authorization": "Bearer abcdefghijklmnopqrst1234567890",
+                            "IB-Context": 'john.doe_acme.com' }
+                
+                # create query parameters
+                params = { "name": "new conversation name",
+                           "description": "new conversation description" }
+                
+                # make the PUT request
+                response = requests.put(url,
+                                        headers=headers,
+                                        params=params)
+                
+                # handle the response
+                if response.status_code == 204:
+                    print("Conversation updated successfully")
+                else:
+                    print(f"Error: {response.status_code} - {response.text}")
+
     delete:
       operationId: deleteConversation
       x-fern-audiences:
@@ -1588,6 +1954,7 @@ paths:
                       -H "IB-Context: ${IB_CONTEXT}"\
                       -H "Content-Type: application/json"
             - sdk: python
+              name: with SDK
               code: |
                   # AI Hub Python SDK example
                   from aihub import AIHub
@@ -1596,6 +1963,25 @@ paths:
                                  api_key="<API-TOKEN>",
                                  ib_context="<IB-CONTEXT>")
                   status = client.conversations.delete('<CONVERSATION-ID>')
+            - sdk: python
+              name: without SDK
+              code: |
+                import requests
+                
+                url = "https://aihub.instabase.com/api/v2/conversations/a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+                headers = { "Authorization": "Bearer abcdefghijklmnopqrst1234567890",
+                                             "IB-Context": 'john.doe_acme.com' }
+                
+                # make the DELETE request
+                response = requests.delete(url,
+                                           headers=headers)
+                
+                # handle the response
+                if response.status_code == 204:
+                    print("Conversation deleted successfully")
+                else:
+                    print(f"Error: {response.status_code} - {response.text}")
+
   /v2/conversations/{conversation_id}/prompts:
     post:
       operationId: converse
@@ -1666,6 +2052,7 @@ paths:
                           "mode": "default"
                         }'
             - sdk: python
+              name: with SDK
               code: |
                   # AI Hub Python SDK example
                   from aihub import AIHub
@@ -1677,6 +2064,32 @@ paths:
                                                          question="What is the main topic of the document?",
                                                          document_ids=[<DOCUMENT-ID>],
                                                          mode="default")
+            - sdk: python
+              name: without SDK
+              code: |
+                import requests
+                
+                url = "https://aihub.instabase.com/api/v2/conversations/a1b2c3d4-e5f6-7890-abcd-ef1234567890/prompts"
+                headers = { "Authorization": "Bearer abcdefghijklmnopqrst1234567890",
+                            "IB-Context": 'john.doe_acme.com',
+                            "Content-Type": "application/json" }
+                
+                # create the request payload
+                data = { "question": "What is the main topic of the document?",
+                         "document_ids": [123456],
+                         "mode": "default" }
+                
+                # make the POST request
+                response = requests.post(url,
+                                         headers=headers,
+                                         json=data)
+                
+                # handle the response
+                if response.status_code == 200:
+                    answer = response.json()
+                    print(f"Answer: {answer['answer']}")
+                else:
+                    print(f"Error: {response.status_code} - {response.text}")
 
   /v2/conversations/{conversation_id}/documents:
     post:
@@ -1735,6 +2148,7 @@ paths:
                     -F files="@/path/to/test.pdf" \
                     -F files="@/path/to/test2.pdf"
             - sdk: python
+              name: with SDK
               code: |
                   # AI Hub Python SDK example
                   from aihub import AIHub
@@ -1744,6 +2158,32 @@ paths:
                                  ib_context="<IB-CONTEXT>")
                   status = client.conversations.add_documents('<CONVERSATION-ID>',
                                                               files=['test.pdf', 'test2.pdf'])
+            - sdk: python
+              name: without SDK
+              code: |
+                import requests
+                
+                url = "https://aihub.instabase.com/api/v2/conversations/a1b2c3d4-e5f6-7890-abcd-ef1234567890/documents"
+                headers = { "Authorization": "Bearer abcdefghijklmnopqrst1234567890",
+                            "IB-Context": 'john.doe_acme.com' }
+                
+                files = [
+                    ('files', ('test1.pdf', open('test1.pdf', 'rb'), 'application/pdf')),
+                    ('files', ('test2.pdf', open('test2.pdf', 'rb'), 'application/pdf'))
+                ]
+                
+                # make the POST request
+                response = requests.post(url,
+                                         headers=headers,
+                                         files=files)
+                
+                # handle the response
+                if response.status_code == 201:
+                    upload_response = response.json()
+                    print("Documents uploaded successfully")
+                else:
+                    print(f"Error: {response.status_code} - {response.text}")
+
     delete:
       operationId: deleteDocumentsFromConversation
       x-fern-audiences:
@@ -1787,6 +2227,7 @@ paths:
                     -H "Content-Type: application/json" \
                     -d '{"ids": [<DOCUMENT-ID>]}'
             - sdk: python
+              name: with SDK
               code: |
                   # AI Hub Python SDK example
                   from aihub import AIHub
@@ -1796,6 +2237,29 @@ paths:
                                  ib_context="<IB-CONTEXT>")
                   status = client.conversations.delete_documents('<CONVERSATION-ID>',
                                                                  ids=[<DOCUMENT-ID>])
+            - sdk: python
+              name: without SDK
+              code: |
+                import requests
+                
+                url = "https://aihub.instabase.com/api/v2/conversations/a1b2c3d4-e5f6-7890-abcd-ef1234567890/documents"
+                headers = { "Authorization": "Bearer abcdefghijklmnopqrst1234567890",
+                            "IB-Context": 'john.doe_acme.com',
+                            "Content-Type": "application/json" }
+                
+                # create the request payload
+                data = { "ids": ["12345"] }
+                
+                # make the DELETE request
+                response = requests.delete(url,
+                                           headers=headers,
+                                           json=data)
+                
+                # handle the response
+                if response.status_code == 204:
+                    print("Documents deleted successfully")
+                else:
+                    print(f"Error: {response.status_code} - {response.text}")
 
   /v2/conversations/{conversation_id}/documents/{document_id}:
     get:
@@ -1839,6 +2303,7 @@ paths:
                     -H "Authorization: Bearer ${API_TOKEN}"\
                     -H "IB-Context: ${IB_CONTEXT}"
             - sdk: python
+              name: with SDK
               code: |
                   # AI Hub Python SDK example
                   from aihub import AIHub
@@ -1848,6 +2313,26 @@ paths:
                                  ib_context="<IB-CONTEXT>")
                   status = client.conversations.get_document_metadata('<CONVERSATION-ID>',
                                                                       document_id=<DOCUMENT-ID>)
+            - sdk: python
+              name: without SDK
+              code: |
+                import requests
+                
+                url = "https://aihub.instabase.com/api/v2/conversations/a1b2c3d4-e5f6-7890-abcd-ef1234567890/documents/123456"
+                headers = { "Authorization": "Bearer abcdefghijklmnopqrst1234567890",
+                            "IB-Context": 'john.doe_acme.com' }
+                
+                # make the GET request
+                response = requests.get(url,
+                                        headers=headers)
+                
+                # handle the response
+                if response.status_code == 200:
+                    document = response.json()
+                    print(f"Document: {document['name']}")
+                else:
+                    print(f"Error: {response.status_code} - {response.text}")
+
   /v2/queries:
     post:
       operationId: runQuery
@@ -1956,6 +2441,7 @@ paths:
                             }
                         }'
             - sdk: python
+              name: with SDK
               code: |
                   # AI Hub Python SDK example
                   from aihub import AIHub
@@ -1971,6 +2457,35 @@ paths:
                                                       source_app=source_app,
                                                       model_name="multistep",
                                                       include_source_info=True)
+            - sdk: python
+              name: without SDK
+              code: |
+                import requests
+                
+                url = "https://aihub.instabase.com/api/v2/queries"
+                headers = { "Authorization": "Bearer abcdefghijklmnopqrst1234567890",
+                            "IB-Context": 'john.doe_acme.com',
+                            "Content-Type": "application/json" }
+                
+                # create the request payload
+                data = { "query": "What is the wingspan of the A380?",
+                         "model_name": "multistep",
+                         "include_source_info": True,
+                         "source_app": { "type": "CHATBOT",
+                                         "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890" } }
+                
+                # make the POST request
+                response = requests.post(url,
+                                         headers=headers,
+                                         json=data)
+                
+                # handle the response
+                if response.status_code == 202:
+                    query_response = response.json()
+                    print(f"Query started with ID: {query_response['query_id']}")
+                else:
+                    print(f"Error: {response.status_code} - {response.text}")
+
   /v2/queries/{query_id}:
     get:
       operationId: getQueryStatus
@@ -2028,14 +2543,35 @@ paths:
                     -H "Authorization: Bearer ${API_TOKEN}" \
                     -H "IB-Context: ${IB_CONTEXT}"'
             - sdk: python
+              name: with SDK
               code: |
-                  # AI Hub Python SDK example
-                  from aihub import AIHub
+                # AI Hub Python SDK example
+                from aihub import AIHub
+                
+                client = AIHub(api_root="<API-ROOT>",
+                               api_key="<API-TOKEN>",
+                               ib_context="<IB-CONTEXT>")
+                status = client.queries.status(query_id="<QUERY-ID>")
+            - sdk: python
+              name: without SDK
+              code: |
+                import requests
 
-                  client = AIHub(api_root="<API-ROOT>",
-                                 api_key="<API-TOKEN>",
-                                 ib_context="<IB-CONTEXT>")
-                  status = client.queries.status(query_id="<QUERY-ID>")
+                url = "https://aihub.instabase.com/api/v2/queries/a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+                headers = { "Authorization": "Bearer abcdefghijklmnopqrst1234567890",
+                            "IB-Context": 'john.doe_acme.com' }
+                
+                # make the GET request
+                response = requests.get(url,
+                                        headers=headers)
+                
+                # handle the response
+                if response.status_code == 200:
+                    query_status = response.json()
+                    print(f"Query status: {query_status['status']}")
+                else:
+                    print(f"Error: {response.status_code} - {response.text}")
+
   /v2/jobs/{job_id}:
     get:
       operationId: jobStatus
@@ -2068,6 +2604,7 @@ paths:
                     -H "Authorization: Bearer ${API_TOKEN}"\
                     -H "IB-Context: ${IB_CONTEXT}"
             - sdk: python
+              name: with SDK
               code: |
                   # AI Hub Python SDK example
                   from aihub import AIHub
@@ -2076,6 +2613,25 @@ paths:
                                  api_key="<API-TOKEN>",
                                  ib_context="<IB-CONTEXT>")
                   resp = client.jobs.status("<JOB-ID>")
+            - sdk: python
+              name: without SDK
+              code: |
+                import requests
+                
+                url = "https://aihub.instabase.com/api/v2/jobs/a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+                headers = { "Authorization": "Bearer abcdefghijklmnopqrst1234567890",
+                            "IB-Context": 'john.doe_acme.com' }
+                
+                # make the GET request
+                response = requests.get(url,
+                                        headers=headers)
+                
+                # handle the response
+                if response.status_code == 200:
+                    job_status = response.json()
+                    print(f"Job status: {job_status['state']}")
+                else:
+                    print(f"Error: {response.status_code} - {response.text}")
 
   /v2/files/{path}:
     get:
@@ -2169,6 +2725,7 @@ paths:
                   -H "Authorization: Bearer ${API_TOKEN}" \
                   -H "IB-Context: ${IB_CONTEXT}"
             - sdk: python
+              name: with SDK
               code: |
                   # AI Hub Python SDK example
                   from aihub import AIHub
@@ -2177,6 +2734,37 @@ paths:
                            ib_context="<IB-CONTEXT>")
 
                   content = client.files.read('<FILE-PATH>', expect_node_type='file')
+            - sdk: python
+              name: without SDK
+              code: |
+                import requests
+                
+                organization_id = 'acme_org'
+                workspace = 'MyWorkspace'
+                drive = 'My Google Drive'
+                folder = 'My Drive/AI Hub files'
+                file_name = 'hello.txt'
+                file_path = f'{organization_id}/{workspace}/fs/{drive}/{folder}/{file_name}'
+                
+                url = f"https://aihub.instabase.com/api/v2/files/{file_path}"
+                headers = { "Authorization": "Bearer abcdefghijklmnopqrst1234567890",
+                            "IB-Context": 'john.doe_acme.com' }
+                
+                # create query parameters
+                params = { "expect-node-type": "file" }
+                
+                # make the GET request
+                response = requests.get(url,
+                                        headers=headers,
+                                        params=params)
+                
+                # handle the response
+                if response.status_code == 200:
+                    file_content = response.content
+                    print(f"File contents: {file_contents}")
+                else:
+                    print(f"Error: {response.status_code} - {response.text}")
+
     put:
       operationId: writeFile
       x-fern-audiences:
@@ -2233,6 +2821,7 @@ paths:
                   -H "Content-Type: application/octet-stream" \
                   --data-binary "@<LOCAL_FILEPATH>"
             - sdk: python
+              name: with SDK
               code: |
                   # AI Hub Python SDK example
                   from aihub import AIHub
@@ -2241,6 +2830,35 @@ paths:
                            ib_context="<IB-CONTEXT>")
                   data = bytes('hello world', 'utf-8')
                   client.files.write('<FILE-PATH>', data)
+            - sdk: python
+              name: without SDK
+              code: |
+                import requests
+                
+                organization_id = 'acme_org'
+                workspace = 'MyWorkspace'
+                drive = 'MyDrive'
+                folder = 'MyFolder'
+                file = 'hello.txt'
+                file_path = f'{organization_id}/{workspace}/fs/{drive}/{folder}/{file}'
+                file_contents = bytes('Hello world', 'utf-8')
+                
+                url = f"https://aihub.instabase.com/api/v2/files/{file_path}"
+                headers = { "Authorization": "Bearer abcdefghijklmnopqrst1234567890",
+                            "IB-Context": 'john.doe_acme.com',
+                            "Content-Type": "application/octet-stream" }
+                
+                # make the PUT request
+                response = requests.put(url,
+                                        headers=headers,
+                                        data=file_contents)
+                
+                # handle the response
+                if response.status_code in [201, 204]:
+                    print("File written successfully")
+                else:
+                    print(f"Error: {response.status_code} - {response.text}")
+
     head:
       operationId: getFileMetadata
       x-fern-audiences:
@@ -2302,6 +2920,7 @@ paths:
                   -H "Authorization: Bearer ${API_TOKEN}" \
                   -H "IB-Context: ${IB_CONTEXT}"
             - sdk: python
+              name: with SDK
               code: |
                   # AI Hub Python SDK example
                   from aihub import AIHub
@@ -2309,6 +2928,33 @@ paths:
                            api_key="<API-TOKEN>",
                            ib_context="<IB-CONTEXT>")
                   client.files.get_file_metadata('<FILE-PATH>')
+            - sdk: python
+              name: without SDK
+              code: |
+                import requests
+                
+                organization_id = 'acme_org'
+                workspace = 'MyWorkspace'
+                drive = 'Instabase Drive'
+                folder = 'MyFolder'
+                file = 'hello.txt'
+                node_path = f'{organization_id}/{workspace}/fs/{drive}/{folder}/{file}'
+                
+                url = f"https://aihub.instabase.com/api/v2/files/{node_path}"
+                headers = { "Authorization": "Bearer abcdefghijklmnopqrst1234567890",
+                            "IB-Context": 'john.doe_acme.com' }
+                
+                # make the HEAD request
+                response = requests.head(url,
+                                         headers=headers)
+                
+                # handle the response
+                if response.status_code == 200:
+                    content_type = response.headers.get('Content-Type')
+                    print(f"File metadata retrieved - Type: {content_type}")
+                else:
+                    print(f"Error: {response.status_code} - {response.text}")
+
     delete:
       operationId: deleteFileOrFolder
       x-fern-audiences:
@@ -2349,6 +2995,7 @@ paths:
                   -H "Authorization: Bearer ${API_TOKEN}" \
                   -H "IB-Context: ${IB_CONTEXT}"
             - sdk: python
+              name: with SDK
               code: |
                   # AI Hub Python SDK example
                   from aihub import AIHub
@@ -2356,6 +3003,32 @@ paths:
                            api_key="<API-TOKEN>",
                            ib_context="<IB-CONTEXT>")
                   client.files.delete('<FILE-PATH>')
+            - sdk: python
+              name: without SDK
+              code: |
+                import requests
+                
+                organization_id = 'acme_org'
+                workspace = 'MyWorkspace'
+                drive = 'Instabase Drive'
+                folder = 'my-folder'
+                file = 'hello.txt'
+                file_path = f'{organization_id}/{workspace}/fs/{drive}/{folder}/{file}'
+                
+                url = f"https://aihub.instabase.com/api/v2/files/{file_path}"
+                headers = { "Authorization": "Bearer abcdefghijklmnopqrst1234567890",
+                            "IB-Context": 'john.doe_acme.com' }
+                
+                # make the DELETE request
+                response = requests.delete(url,
+                                           headers=headers)
+                
+                # handle the response
+                if response.status_code == 202:
+                    print("File deletion request accepted")
+                else:
+                    print(f"Error: {response.status_code} - {response.text}")
+
   /v2/aihub/secrets:
     get:
       operationId: listSecrets
@@ -2421,6 +3094,29 @@ paths:
                               api_key="<API-TOKEN>",
                               ib_context="<IB-CONTEXT>")
                 resp = client.secrets.list(workspace=<WORKSPACE>)
+          - sdk: python
+            name: without SDK
+            code: |
+              import requests
+              
+              url = "https://aihub.instabase.com/api/v2/aihub/secrets"
+              headers = { "Authorization": "Bearer abcdefghijklmnopqrst1234567890",
+                          "IB-Context": 'john.doe_acme.com' }
+              
+              # create query parameters
+              params = { "workspace": "My workspace" }
+              
+              # make the GET request
+              response = requests.get(url,
+                                      headers=headers,
+                                      params=params)
+              
+              # handle the response
+              if response.status_code == 200:
+                  secrets = response.json()
+                  print(f"Retrieved {len(secrets['secrets'])} secrets")
+              else:
+                  print(f"Error: {response.status_code} - {response.text}")
 
     post:
       operationId: createSecret
@@ -2494,6 +3190,7 @@ paths:
                           "allowed_workspaces": ["workspace1", "workspace2"]
                         }'
             - sdk: python
+              name: with SDK
               code: |
                   # AI Hub Python SDK example
                   from aihub import AIHub
@@ -2509,6 +3206,34 @@ paths:
                     allowed_workspaces_type="SOME",
                     # only required when allowed_workspaces_type="SOME"
                     allowed_workspaces=['workspace1', 'workspace2'])
+            - sdk: python
+              name: without SDK
+              code: |
+                import requests
+                
+                url = "https://aihub.instabase.com/api/v2/aihub/secrets"
+                headers = { "Authorization": "Bearer abcdefghijklmnopqrst1234567890",
+                            "IB-Context": 'john.doe_acme.com',
+                            "Content-Type": "application/json" }
+                
+                # create the request payload
+                data = { "alias": "my_secret",
+                         "description": "Sample secret",
+                         "value": "my password",
+                         "allowed_workspaces_type": "SOME",
+                         "allowed_workspaces": ["workspace1", "workspace2"] }
+                
+                # make the POST request
+                response = requests.post(url,
+                                         headers=headers,
+                                         json=data)
+                
+                # handle the response
+                if response.status_code == 200:
+                    print("Secret created successfully")
+                else:
+                    print(f"Error: {response.status_code} - {response.text}")
+
     patch:
       operationId: updateSecret
       x-fern-audiences:
@@ -2577,6 +3302,7 @@ paths:
                           "allowed_workspaces_type": "ALL"
                         }'
             - sdk: python
+              name: with SDK
               code: |
                   # AI Hub Python SDK example
                   from aihub import AIHub
@@ -2639,6 +3365,7 @@ paths:
                           "alias": "my_secret"
                         }'
             - sdk: python
+              name: with SDK
               code: |
                   # AI Hub Python SDK example
                   from aihub import AIHub
@@ -2650,6 +3377,30 @@ paths:
                   result = client.secrets.delete(
                       alias="my_secret"
                   )
+            - sdk: python
+              name: without SDK
+              code: |
+                import requests
+                
+                url = "https://aihub.instabase.com/api/v2/aihub/secrets"
+                headers = { "Authorization": "Bearer abcdefghijklmnopqrst1234567890",
+                            "IB-Context": 'john.doe_acme.com',
+                            "Content-Type": "application/json" }
+                
+                # create the request payload
+                data = { "alias": "my_secret" }
+                
+                # make the DELETE request
+                response = requests.delete(url,
+                                           headers=headers,
+                                           json=data)
+                
+                # handle the response
+                if response.status_code == 200:
+                    print("Secret deleted successfully")
+                else:
+                    print(f"Error: {response.status_code} - {response.text}")
+
   /v1/auditlogs:
     post:
       operationId: getAuditLogs
@@ -2659,7 +3410,9 @@ paths:
       description: |
         Retrieve audit logs based on specified filters. Returns a paginated list of audit log entries.
 
-        <Note>The audit logs feature is available for Enterprise-tier organizations with single-tenant environments. To use this endpoint, you must have audit log access permissions. Contact Instabase Support to request access to audit logs for your organization.</Note>
+        <Note>This API operation is available for Enterprise-tier organizations with single-tenant environments. To use it you must have audit log access permissions. Contact Instabase Support to request access to audit logs for your organization.</Note>
+        
+        <Note>This API operation is not supported by the SDK but you can access it from Python by making direct REST calls, as shown in the sample code.</Note>
       requestBody:
         required: true
         content:
@@ -2756,6 +3509,34 @@ paths:
                           "start_time": "1749139277810",
                           "start": 200
                         }'
+            - sdk: python
+              name: without SDK
+              code: |
+                # SDK does not support this operation, so you
+                # must make REST calls using "requests" module
+                import requests
+                
+                url = "https://aihub.instabase.com/api/v1/auditlogs"
+                headers = { "Authorization": "Bearer abcdefghijklmnopqrst1234567890",
+                            "Content-Type": "application/json" }
+                
+                # create the request payload
+                data = { "log_type": "org_secret",
+                         "size": 50,
+                         "start_time": "1749139277810",
+                         "start": 200 }
+                
+                # make the POST request
+                response = requests.post(url,
+                                         headers=headers,
+                                         json=data)
+                
+                # handle the response
+                if response.status_code == 200:
+                    audit_logs = response.json()
+                    print(f"Retrieved {len(audit_logs['data']['results'])} audit logs")
+                else:
+                    print(f"Error: {response.status_code} - {response.text}")
 
 components:
   securitySchemes:
@@ -2772,7 +3553,7 @@ components:
         type: string
       required: false
       description: Specify whether to use your community account or organization account to complete the request. To use your community account, define as your user ID. To use your organization account, define as your organization ID.
-                   If unspecified, defaults to community account context. See [Authorization and context identification](/api-sdk/authorization#ib-context-header) for details.
+        If unspecified, defaults to community account context. See [Authorization and context identification](/api-sdk/authorization#ib-context-header) for details.
     batch_id:
       in: path
       name: batch_id

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -81,6 +81,31 @@ paths:
                            ib_context="<IB-CONTEXT>")
 
                   batch = client.batches.create(name='test')
+            - sdk: python
+              name: without SDK
+              code: |
+                import requests
+
+                url = "https://aihub.instabase.com/api/v2/batches"
+                headers = { "Authorization": "Bearer abcdefghijklmnopqrst1234567890",
+                            "IB-Context": 'john.doe_acme.com',
+                            "Content-Type": "application/json" }
+
+                # create the request payload
+                data = { "name": "my batch" }
+
+                # make the POST request
+                response = requests.post(url,
+                                         headers=headers,
+                                         json=data)
+
+                # handle the response
+                if response.status_code == 200:
+                    batch = response.json()
+                    print(f"Batch created with ID: {batch['id']}")
+                else:
+                    print(f"Error: {response.status_code} - {response.text}")
+
     get:
       operationId: listBatches
       x-fern-audiences:
@@ -149,20 +174,20 @@ paths:
               name: without SDK
               code: |
                 import requests
-                
+
                 url = "https://aihub.instabase.com/api/v2/batches"
                 headers = { "Authorization": "Bearer abcdefghijklmnopqrst1234567890",
                             "IB-Context": 'john.doe_acme.com' }
-                
+
                 # create query parameters
                 params = { "workspace": "Development-Workspace",
                            "limit": 100 }
-                
-                # Make the GET request
+
+                # make the GET request
                 response = requests.get(url,
                                         headers=headers,
                                         params=params)
-                
+
                 # handle the response
                 if response.status_code == 200:
                     batches = response.json()
@@ -208,6 +233,26 @@ paths:
                                  api_key="<API-TOKEN>",
                                  ib_context="<IB-CONTEXT>")
                   batch = client.batches.get("<BATCH-ID>")
+            - sdk: python
+              name: without SDK
+              code: |
+                import requests
+
+                url = "https://aihub.instabase.com/api/v2/batches/<BATCH-ID>"
+                headers = { "Authorization": "Bearer abcdefghijklmnopqrst1234567890",
+                                             "IB-Context": 'john.doe_acme.com' }
+
+                # make the GET request
+                response = requests.get(url,
+                                        headers=headers)
+
+                # handle the response
+                if response.status_code == 200:
+                    batch = response.json()
+                    print(f"Batch: {batch['name']}")
+                else:
+                    print(f"Error: {response.status_code} - {response.text}")
+
     delete:
       operationId: deleteBatch
       x-fern-audiences:
@@ -257,15 +302,15 @@ paths:
               name: without SDK
               code: |
                 import requests
-                
+
                 url = "https://aihub.instabase.com/api/v2/batches/123456"
                 headers = { "Authorization": "Bearer abcdefghijklmnopqrst1234567890",
                                              "IB-Context": 'john.doe_acme.com' }
-                
-                # Make the DELETE request
+
+                # make the DELETE request
                 response = requests.delete(url,
                                            headers=headers)
-                
+
                 # handle the response
                 if response.status_code == 202:
                     job_response = response.json()
@@ -354,7 +399,7 @@ paths:
                 headers = { "Authorization": "Bearer abcdefghijklmnopqrst1234567890",
                             "IB-Context": "john.doe_acme.com" }
                 
-                # Make the GET request
+                # make the GET request
                 response = requests.get(url,
                                         headers=headers)
                 
@@ -436,11 +481,11 @@ paths:
                                              "IB-Context": 'john.doe_acme.com',
                                              "Content-Type": "application/octet-stream" }
                 
-                # Read the file contents
+                # read the file contents
                 with open('path/to/local/test.pdf', 'rb') as file:
                     file_content = file.read()
                 
-                # Make the PUT request
+                # make the PUT request
                 response = requests.put(url,
                                         headers=headers,
                                         data=file_content)
@@ -500,7 +545,7 @@ paths:
                 headers = { "Authorization": "Bearer abcdefghijklmnopqrst1234567890",
                             "IB-Context": 'john.doe_acme.com' }
                 
-                # Make the DELETE request
+                # make the DELETE request
                 response = requests.delete(url,
                                            headers=headers)
                 
@@ -560,7 +605,7 @@ paths:
                 headers = { "Authorization": "Bearer abcdefghijklmnopqrst1234567890",
                             "IB-Context": 'john.doe_acme.com' }
                 
-                # Make the GET request
+                # make the GET request
                 response = requests.get(url,
                                         headers=headers)
                 
@@ -723,7 +768,7 @@ paths:
                 data = { "batch_id": "123456",
                          "app_name": "My App" }
                 
-                # Make the POST request
+                # make the POST request
                 response = requests.post(url,
                                          headers=headers,
                                          json=data)
@@ -763,6 +808,39 @@ paths:
                   result = client.apps.runs.create(app_name='<APP-NAME>',
                                                    batch_id='<BATCH-ID>',
                                                    settings={"runtime_config":{"generate_post_process_pdf": true}})
+            - sdk: python
+              name: Post-processed-pdf generation without SDK
+              code: |
+                  import requests
+
+                  url = "https://aihub.instabase.com/api/v2/apps/runs"
+                  headers = { "Authorization": "Bearer abcdefghijklmnopqrst1234567890",
+                              "IB-Context": 'john.doe_acme.com',
+                              "Content-Type": "application/json" }
+
+                  # create the request payload
+                  data = {
+                      "batch_id": "123456",
+                      "app_name": "My App",
+                      "settings": {
+                          "runtime_config": {
+                              "generate_post_process_pdf": True
+                          }
+                      }
+                  }
+
+                  # make the POST request
+                  response = requests.post(url,
+                                           headers=headers,
+                                           json=data)
+
+                  # handle the response
+                  if response.status_code == 200:
+                      run = response.json()
+                      print(f"Run started with ID: {run['id']}")
+                  else:
+                      print(f"Error: {response.status_code} - {response.text}")
+
     get:
       operationId: listRuns
       x-fern-audiences:
@@ -892,7 +970,7 @@ paths:
                 headers = { "Authorization": "Bearer abcdefghijklmnopqrst1234567890",
                             "IB-Context": 'john.doe_acme.com' }
                 
-                # Make the GET request
+                # make the GET request
                 response = requests.get(url,
                                         headers=headers)
                 
@@ -1041,7 +1119,7 @@ paths:
                 # create the request payload
                 data = { "batch_id": "123456" }
                 
-                # Make the POST request
+                # make the POST request
                 response = requests.post(url,
                                         headers=headers,
                                         json=data)
@@ -1105,7 +1183,7 @@ paths:
                 headers = { "Authorization": "Bearer abcdefghijklmnopqrst1234567890",
                             "IB-Context": 'john.doe_acme.com' }
                 
-                # Make the GET request
+                # make the GET request
                 response = requests.get(url,
                                         headers=headers)
                 
@@ -1222,7 +1300,7 @@ paths:
                 headers = { "Authorization": "Bearer abcdefghijklmnopqrst1234567890",
                             "IB-Context": 'john.doe_acme.com' }
                 
-                # Make the DELETE request
+                # make the DELETE request
                 response = requests.delete(url,
                                           headers=headers)
                 
@@ -1443,7 +1521,7 @@ paths:
                 headers = { "Authorization": "Bearer abcdefghijklmnopqrst1234567890",
                             "IB-Context": 'john.doe_acme.com' }
                 
-                # Make the GET request
+                # make the GET request
                 response = requests.get(url,
                                         headers=headers)
                 
@@ -1525,7 +1603,7 @@ paths:
                 headers = { "Authorization": "Bearer abcdefghijklmnopqrst1234567890",
                             "IB-Context": 'john.doe_acme.com' }
                 
-                # Make the GET request
+                # make the GET request
                 response = requests.get(url,
                                         headers=headers)
                 
@@ -1850,6 +1928,25 @@ paths:
                                  api_key="<API-TOKEN>",
                                  ib_context="<IB-CONTEXT>")
                   result = client.conversations.status(<CONVERSATION-ID>)
+            - sdk: python
+              name: without SDK
+              code: |
+                  import requests
+
+                  url = "https://aihub.instabase.com/api/v2/conversations/a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+                  headers = { "Authorization": "Bearer abcdefghijklmnopqrst1234567890",
+                              "IB-Context": 'john.doe_acme.com' }
+
+                  # make the GET request
+                  response = requests.get(url,
+                                          headers=headers)
+
+                  # handle the response
+                  if response.status_code == 200:
+                      conversation = response.json()
+                      print(f"Conversation: {conversation['name']}")
+                  else:
+                      print(f"Error: {response.status_code} - {response.text}")
 
     put:
       operationId: updateConversation
@@ -2547,7 +2644,7 @@ paths:
               code: |
                 # AI Hub Python SDK example
                 from aihub import AIHub
-                
+
                 client = AIHub(api_root="<API-ROOT>",
                                api_key="<API-TOKEN>",
                                ib_context="<IB-CONTEXT>")
@@ -3086,6 +3183,7 @@ paths:
                   -H "Authorization: Bearer ${API_TOKEN}" \
                   -H "IB-Context: ${IB_CONTEXT}"
           - sdk: python
+            name: with SDK
             code: |
                 # AI Hub Python SDK example
                 from aihub import AIHub
@@ -3316,6 +3414,31 @@ paths:
                       value="new password",
                       allowed_workspaces_type="ALL"
                   )
+            - sdk: python
+              name: without SDK
+              code: |
+                  import requests
+                    
+                  url = "https://aihub.instabase.com/api/v2/aihub/secrets"
+                  headers = { "Authorization": "Bearer abcdefghijklmnopqrst1234567890",
+                              "IB-Context": 'john.doe_acme.com',
+                              "Content-Type": "application/json" }
+                  
+                  # create the request payload
+                  data = { "alias": "my_secret",
+                           "value": "new password",
+                           "allowed_workspaces_type": "ALL" }
+                  
+                  # make the PATCH request
+                  response = requests.patch(url,
+                                            headers=headers,
+                                            json=data)
+                  
+                  # handle the response
+                  if response.status_code == 200:
+                      print("Secret updated successfully")
+                  else:
+                      print(f"Error: {response.status_code} - {response.text}")
 
     delete:
       operationId: deleteSecret


### PR DESCRIPTION
Adds sample code showing how to use each API operation with Python and the `requests` module to make direct REST calls instead of the SDK.

Requested by Subramanya Hegde in DOCS-1354
