### PR TITLE
[DOCS-1532] Fix inaccurate delete-batch and delete-run API docs samples

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -296,13 +296,13 @@ paths:
       tags:
         - Batches
       summary: Delete batch
-      description: Delete a batch and all its files. This is an asynchronous operation that must be [checked for completion](/api-sdk/api-reference/batches/poll-batches-job).
+      description: Delete a batch and all its files. This is an asynchronous operation that must be [checked for completion](/api-sdk/api-reference/jobs/job-status).
       parameters:
         - $ref: '#/components/parameters/batch_id'
         - $ref: '#/components/parameters/ib_context'
       responses:
         '202':
-          description: Batch deletion request accepted. [Poll the job ID](/api-sdk/api-reference/batches/poll-batches-job) to check completion status.
+          description: Batch deletion request accepted. [Poll the job ID](/api-sdk/api-reference/jobs/job-status) to check completion status.
           content:
             application/json:
               schema:
@@ -331,14 +331,17 @@ paths:
                   
                   delete_response = client.batches.delete(batch_id=12345)
                   
-                  # check delete job status until done
+                  # poll the job until it reaches a terminal state
                   while True:
-                      poll_response = client.batches.poll_job(
-                                          job_id=delete_response.job_id
-                                      )
-                      if poll_response.state not in ["PENDING", "RUNNING"]:
+                      status_response = client.jobs.status(
+                          job_id=delete_response.job_id
+                      )
+                      if status_response.state not in ["PENDING", "RUNNING"]:
                           break
                       time.sleep(3)  # pause before polling the status again
+                  
+                  if status_response.state != "COMPLETE":
+                      print(f"Deletion ended in state {status_response.state}")
 
             - sdk: python
               name: without SDK
@@ -1137,13 +1140,14 @@ paths:
       description: |
         Poll the asynchronous job created when deleting a batch.
 
-        <Info>This API operation and SDK method are maintained for backward compatibility, but the functionally identical API operation [poll file operation job status](/api-sdk/api-reference/jobs/job-status) and its corresponding SDK method [client.jobs.status()](/api-sdk/api-reference/jobs/job-status) are preferred.</Info>
+        <Info>This endpoint and the SDK method `client.batches.poll_job()` are maintained for backward compatibility, but they are an outdated way to check job status. Prefer the functionally identical [poll file operation job status](/api-sdk/api-reference/jobs/job-status) endpoint and its SDK method `client.jobs.status()`.</Info>
       parameters:
         - name: job_id
           in: path
           required: true
           schema:
             type: string
+          example: a1b2c3d4-e5f6-7890-abcd-ef1234567890
           description: The job ID returned by a [Delete batch](/api-sdk/api-reference/batches/delete-batch) request.
         - $ref: '#/components/parameters/ib_context'
       responses:
@@ -1979,7 +1983,7 @@ paths:
           description: Delete the run's logs.
       responses:
         '202':
-          description: Run deleted successfully.
+          description: Run deletion request accepted. The response contains a job ID for each file deletion that started, so a key is absent if you set its corresponding option to `false`. [Poll each job ID](/api-sdk/api-reference/jobs/job-status) to check completion status.
           content:
             application/json:
               schema:
@@ -1987,16 +1991,13 @@ paths:
                 properties:
                   delete_input_dir_job_id:
                     type: string
-                    description: Job ID for deleting the input directory.
-                    nullable: true
+                    description: Job ID for deleting the input directory. Returned only when `delete_input` is `true` and the deletion job started.
                   delete_output_dir_job_id:
                     type: string
-                    description: Job ID for deleting the output directory.
-                    nullable: true
+                    description: Job ID for deleting the output directory. Returned only when `delete_output` is `true` and the deletion job started.
                   delete_log_dir_job_id:
                     type: string
-                    description: Job ID for deleting the log directory.
-                    nullable: true
+                    description: Job ID for deleting the log directory. Returned only when `delete_logs` is `true` and the deletion job started.
         default:
           description: Error response.
           content:
@@ -2027,22 +2028,25 @@ paths:
                       run_id="a1b2c3d4-e5f6-7890-abcd-ef1234567890"
                   )
                   
+                  # a job ID is returned only for the files that are deleted
                   job_ids = [
-                      response.delete_input_dir_job_id,
-                      response.delete_output_dir_job_id,
-                      response.delete_log_dir_job_id
+                      job_id for job_id in [
+                          response.delete_input_dir_job_id,
+                          response.delete_output_dir_job_id,
+                          response.delete_log_dir_job_id
+                      ] if job_id
                   ]
                   
-                  # remove empty job IDs
-                  job_ids = [job_id for job_id in job_ids if job_id]
-                  
-                  # poll for job completion
+                  # poll each job until it reaches a terminal state
                   while job_ids:
                       for job_id in job_ids[:]:
-                          job_status = client.jobs.status(job_id)
-                          if job_status.state == "COMPLETE":
+                          state = client.jobs.status(job_id).state
+                          if state in ["COMPLETE", "FAILED", "CANCELLED"]:
                               job_ids.remove(job_id)
-                      time.sleep(5)
+                              if state != "COMPLETE":
+                                  print(f"Job {job_id} ended in state {state}")
+                      if job_ids:
+                          time.sleep(5)  # pause before polling again
 
             - sdk: python
               name: without SDK
@@ -2063,11 +2067,17 @@ paths:
                   # handle the response
                   if response.status_code == 202:
                       print("Run deletion request accepted")
-                      print(f"Delete input dir job ID: {response.json()['delete_input_dir_job_id']}")
-                      print(f"Delete output dir job ID: {response.json()['delete_output_dir_job_id']}")
-                      print(f"Delete log dir job ID: {response.json()['delete_log_dir_job_id']}")
+                      # a job ID is returned only for the files that are deleted
+                      job_ids = response.json()
+                      for key in ["delete_input_dir_job_id",
+                                  "delete_output_dir_job_id",
+                                  "delete_log_dir_job_id"]:
+                          if key in job_ids:
+                              print(f"{key}: {job_ids[key]}")
                   else:
                       print(f"Error: {response.status_code} - {response.text}")
+                  
+                  # not included here: poll each job ID until it's done
 
   /v2/apps/runs/{run_id}/results:
     get:
@@ -2570,6 +2580,7 @@ paths:
           required: true
           schema:
             type: string
+          example: a1b2c3d4-e5f6-7890-abcd-ef1234567890
           description: The job ID returned by a request.
         - $ref: '#/components/parameters/ib_context'
       responses:
@@ -3876,6 +3887,7 @@ components:
       required: true
       schema:
         type: integer
+      example: 12345
       description: The batch ID.
     run_id:
       in: path
@@ -3883,6 +3895,7 @@ components:
       required: true
       schema:
         type: string
+      example: a1b2c3d4-e5f6-7890-abcd-ef1234567890
       description: The run ID.
   schemas:
     batch:
@@ -3980,7 +3993,7 @@ components:
       properties:
         job_id:
           type: string
-          description: The job ID of the operation. Use the job ID with the [Poll batches job endpoint](/api-sdk/api-reference/batches/poll-batches-job) to check batch deletion status.
+          description: The job ID of the operation. Use the job ID with the [poll file operation job status](/api-sdk/api-reference/jobs/job-status) endpoint to check batch deletion status.
       required:
         - job_id
     jobStatusResponse:


### PR DESCRIPTION
## Context

Two in-site feedback reports flagged inaccurate code samples on:

- https://docs.instabase.com/api-sdk/api-reference/batches/delete-batch
- https://docs.instabase.com/api-sdk/api-reference/runs/delete-run

The reports included no further detail beyond there being code sample issues.

<img width="1183" height="394" alt="Screenshot 2026-07-28 at 4 49 55 PM" src="https://github.com/user-attachments/assets/571a6595-5440-40d4-b760-59c3644db2ed" />

 As I'm not involved in the backend, I set Cursor in the issue. To investigate, I asked Cursor to verify the published samples against:

1. This OpenAPI spec (source of the Fern docs)
2. The published Python SDK (`instabase-aihub` 0.14.0)
3. The Instabase monorepo server handlers for these endpoints
4. A local Fern docs preview after temporarily copying this branch’s spec into `instabase-fern`

## What Cursor found

### Delete run — real defects

1. **Python “without SDK” sample raised `KeyError`** when indexing `delete_input_dir_job_id` / `delete_output_dir_job_id` / `delete_log_dir_job_id` directly. The server omits those keys when the matching query flag is `false` (or when that filesystem delete is not enqueued). It does **not** return `null`. Verified in `py/src/instabase/jobs/job_handler.py` (`delete_job_ids` starts empty; keys are inserted only inside the corresponding `if delete_input:` / `if delete_output:` / `if delete_logs:` branches) and returned verbatim as the 202 payload from `apps.py`.
2. **Python “with SDK” sample could loop forever** if a deletion job ended in `FAILED` or `CANCELLED`. The sample only removed job IDs on `COMPLETE`. Terminal states confirmed in `file_service.proto` (`COMPLETE`, `FAILED`, `CANCELLED`) and surfaced by the shared job-status handler.
3. **Fern-generated language snippets used a literal `run_id` in the URL** (for example `.../apps/runs/run_id`), which 404s if copy-pasted. Cause: the `run_id` path parameter had no `example` value, so Fern fell back to the parameter name.

### Delete batch — no broken Python sample, but related polish and shared docs issues

The delete-batch Python samples matched the API/SDK behavior (202 + `{"job_id": ...}`, polled successfully). Remaining issues were:

1. The sample used the **legacy** `client.batches.poll_job()` path, while the preferred equivalent is `client.jobs.status()` (already documented on the poll-batches-job page as preferred).
2. The sample exited on any non-`PENDING`/`RUNNING` state without telling the reader when deletion failed.
3. Prose links from delete-batch still pointed readers at the legacy poll-batches-job page even after the sample switched to the preferred method.
4. Shared with delete-run: missing path-parameter `example` values caused weak/placeholder URLs in generated language tabs (integer params fell back to values like `1` / `0`).

## Fixes in this PR

### Delete run

- Python “with SDK”: treat `COMPLETE`, `FAILED`, and `CANCELLED` as terminal; report non-success terminal states; skip the final sleep when done.
- Python “without SDK”: print job IDs only when present (`if key in job_ids`), matching server “omit key” behavior.
- 202 response description: clarify async acceptance, that keys are absent when the corresponding option is `false`, and link to job-status polling.
- Response schema: remove incorrect `nullable: true` from the three job-ID properties; describe when each key is returned.

### Delete batch

- Python “with SDK”: switch polling from `client.batches.poll_job()` to preferred `client.jobs.status()`; report when the terminal state is not `COMPLETE`.
- Retarget “checked for completion” / “Poll the job ID” / `job_id` field links from legacy poll-batches-job to preferred `/jobs/job-status`.

### Legacy poll-batches-job page (kept)

- Kept the endpoint and its samples for backward compatibility.
- Clarified the existing Info callout: maintained for compatibility, but an outdated way to check status; prefer poll file operation job status / `client.jobs.status()`.

### Path-parameter examples (docs rendering)

- Added `example` values for `batch_id`, `run_id`, and both `job_id` path parameters so Fern-generated snippets substitute real example values instead of parameter-name placeholders.

## Testing

- Extracted the updated Python samples from this spec and executed them against mocked SDK/`requests` layers covering:
  - happy path (`COMPLETE`)
  - terminal `FAILED` / `CANCELLED` (previously hung on delete-run)
  - missing job-ID keys (previously `KeyError` on delete-run)
  - delete-batch regression for both with/without SDK samples
- Verified SDK method signatures/response models against published `instabase-aihub` 0.14.0.
- Verified server behavior against the Instabase monorepo handlers/proto noted above.
- Temporarily copied this spec into a local `fern docs dev` preview and confirmed on localhost that:
  - delete-run generated JS URL uses the UUID example (no literal `run_id`)
  - delete-run response copy/schema descriptions match the fixes
  - delete-batch Python sample uses `client.jobs.status()`
  - Temporary fern copy was reverted afterward; this PR is **aihub-openapi only**

## Next steps (outside this PR)

1. Optionally regenerate the Python SDK if we want generated models to drop the prior `nullable` marking on the delete-run 202 response fields (behaviorally optional either way; server never sends `null`).
2. Optional follow-up: other path parameters (`filename`, `session_id`, `path`, etc.) still lack `example` values and can produce similar placeholder URLs on their pages.

## What to review

- [ ] Delete-run Python samples (with SDK + without SDK)
- [ ] Delete-batch Python “with SDK” sample and polling links
- [ ] Delete-run 202 schema/descriptions (keys omitted, not null)
- [ ] Legacy poll-batches-job Info callout still accurate
- [ ] Path-parameter `example` values look reasonable for generated snippets


Made with Cursor