### PR TITLE
Allow null review modification messages

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4315,9 +4315,8 @@ components:
             properties:
               message:
                 type: string
+                nullable: true
                 description: Message associated with the edit history modification.
-            required:
-              - message
       required:
         - timestamp
         - user_id


### PR DESCRIPTION

## Summary
To fix - https://instabase.atlassian.net/browse/PRODENG1-497
- Mark review modification `message` as nullable and optional.
- Prevent generated Python SDK deserialization failures when reviewer comments are absent.

## Testing

- Not run; OpenAPI schema-only change.